### PR TITLE
New monitoring

### DIFF
--- a/internal/commands/cmd.monitor.go
+++ b/internal/commands/cmd.monitor.go
@@ -3,18 +3,36 @@ package commands
 import (
 	"context"
 	"errors"
-	"strconv"
+	"os"
+	"time"
 
 	"github.com/nathan-fiscaletti/letstry/internal/session_manager"
 )
 
 var (
-	ErrMissingArgumentPID = errors.New("monitor: missing required argument PID")
+	ErrMissingArgumentDelay    = errors.New("monitor: missing required argument 'delay'")
+	ErrMissingArgumentLocation = errors.New("monitor: missing required argument 'location'")
 )
 
 func Monitor(ctx context.Context, args []string) error {
 	if len(args) < 1 {
-		return ErrMissingArgumentPID
+		return ErrMissingArgumentDelay
+	}
+
+	if len(args) < 2 {
+		return ErrMissingArgumentLocation
+	}
+
+	delay, err := time.ParseDuration(args[0])
+	if err != nil {
+		return err
+	}
+
+	location := args[1]
+
+	_, err = os.Stat(location)
+	if err != nil {
+		return err
 	}
 
 	manager, err := session_manager.GetSessionManager(ctx)
@@ -22,12 +40,8 @@ func Monitor(ctx context.Context, args []string) error {
 		return err
 	}
 
-	intVal, err := strconv.Atoi(args[0])
-	if err != nil {
-		return err
-	}
-
 	return manager.MonitorSession(ctx, session_manager.MonitorSessionArguments{
-		PID: intVal,
+		Delay:    delay,
+		Location: location,
 	})
 }

--- a/internal/session_manager/cmd.create-session.go
+++ b/internal/session_manager/cmd.create-session.go
@@ -8,14 +8,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/nathan-fiscaletti/letstry/internal/config"
 	"github.com/nathan-fiscaletti/letstry/internal/logging"
 	"github.com/nathan-fiscaletti/letstry/internal/util/identifier"
 	"github.com/otiai10/copy"
-	"github.com/shirou/gopsutil/process"
 )
 
 type CreateSessionArguments struct {
@@ -93,8 +91,6 @@ func (s *sessionManager) CreateSession(ctx context.Context, args CreateSessionAr
 		}
 	}
 
-	startTime := time.Now()
-
 	// Launch the editor
 	logger.Printf("launching editor %s\n", editor.String())
 	cfgArgs := strings.Split(editor.Args, " ")
@@ -105,46 +101,9 @@ func (s *sessionManager) CreateSession(ctx context.Context, args CreateSessionAr
 		return zeroValue, fmt.Errorf("failed to run editor: %v", err)
 	}
 
-	// Give the process time to start
-	logger.Printf("waiting %v for editor process to start\n", editor.ProcessCaptureDelay)
-	time.Sleep(editor.ProcessCaptureDelay)
-
-	logger.Printf("searching for editor process\n")
-	processes, err := process.Processes()
-	if err != nil {
-		return zeroValue, fmt.Errorf("failed to get processes: %v", err)
-	}
-
-	// Find the editor process based on the start time
-	var editorProcess *process.Process
-	for _, p := range processes {
-		name, err := p.Name()
-		if err == nil {
-			if strings.Contains(strings.ToLower(name), strings.ToLower(editor.GetExecName())) {
-				createTime, err := p.CreateTime()
-				if err != nil {
-					continue
-				}
-
-				processStartTime := time.Unix(0, createTime*int64(time.Millisecond))
-				if processStartTime.After(startTime) {
-					editorProcess = p
-					break
-				}
-			}
-		}
-	}
-
-	if editorProcess == nil {
-		return zeroValue, fmt.Errorf("failed to find editor process")
-	}
-
-	logger.Printf("found editor process with PID %v\n", editorProcess.Pid)
-
 	// Create the session
 	newSession := session{
 		ID:       identifier.NewID(),
-		PID:      int32(editorProcess.Pid),
 		Location: tempDir,
 		Source:   sessionSource{SourceType: sourceType, Value: args.Source},
 		Editor:   editor,
@@ -161,7 +120,7 @@ func (s *sessionManager) CreateSession(ctx context.Context, args CreateSessionAr
 	// Call this application again, but start it in the background as it's own process.
 	// This will allow the user to continue using the current terminal session.
 	logger.Printf("starting monitor process for session %s\n", newSession.FormattedID())
-	cmd = exec.Command(os.Args[0], "monitor", fmt.Sprintf("%d", editorProcess.Pid))
+	cmd = exec.Command(os.Args[0], "monitor", fmt.Sprintf("%v", editor.ProcessCaptureDelay), fmt.Sprintf("%s", newSession.Location))
 	err = cmd.Start()
 	if err != nil {
 		return zeroValue, fmt.Errorf("failed to start monitor process: %v", err)

--- a/internal/session_manager/cmd.create-session.go
+++ b/internal/session_manager/cmd.create-session.go
@@ -120,7 +120,7 @@ func (s *sessionManager) CreateSession(ctx context.Context, args CreateSessionAr
 	// Call this application again, but start it in the background as it's own process.
 	// This will allow the user to continue using the current terminal session.
 	logger.Printf("starting monitor process for session %s\n", newSession.FormattedID())
-	cmd = exec.Command(os.Args[0], "monitor", fmt.Sprintf("%v", editor.ProcessCaptureDelay), fmt.Sprintf("%s", newSession.Location))
+	cmd = exec.Command(os.Args[0], "monitor", fmt.Sprintf("%v", editor.ProcessCaptureDelay), newSession.Location)
 	err = cmd.Start()
 	if err != nil {
 		return zeroValue, fmt.Errorf("failed to start monitor process: %v", err)

--- a/internal/session_manager/session.go
+++ b/internal/session_manager/session.go
@@ -6,7 +6,6 @@ import (
 	"github.com/fatih/color"
 	"github.com/nathan-fiscaletti/letstry/internal/config"
 	"github.com/nathan-fiscaletti/letstry/internal/util/identifier"
-	"github.com/shirou/gopsutil/process"
 )
 
 type sessionSource struct {
@@ -42,36 +41,15 @@ func (s sessionSource) FormattedString() string {
 
 type session struct {
 	ID       identifier.ID `json:"id"`
-	PID      int32         `json:"pid"`
 	Location string        `json:"location"`
 	Source   sessionSource `json:"source"`
 	Editor   config.Editor `json:"editor"`
 }
 
-// GetProcess returns the process for the session
-func (s *session) GetProcess() (*process.Process, error) {
-	return process.NewProcess(s.PID)
-}
-
-// IsRunning returns true if the session is running
-func (s *session) IsRunning() bool {
-	_, err := process.NewProcess(s.PID)
-	return err == nil
-}
-
-func (s *session) Kill() {
-	proc, err := s.GetProcess()
-	if err != nil {
-		return
-	}
-
-	proc.Kill()
-}
-
 func (s *session) String() string {
 	src := s.Source.FormattedString()
 	id := s.FormattedID()
-	editor := color.BlueString("(%s, PID %d)", s.Editor.Name, s.PID)
+	editor := color.BlueString("(%s)", s.Editor.Name)
 
 	return fmt.Sprintf("id=%s, editor=%s, src=%s", id, editor, src)
 }

--- a/internal/session_manager/sessions.go
+++ b/internal/session_manager/sessions.go
@@ -44,13 +44,6 @@ func (s *sessionManager) GetCurrentSession(ctx context.Context) (session, error)
 	return sess, err
 }
 
-// GetSessionForPID returns the session with the given PID
-func (s *sessionManager) GetSessionForPID(ctx context.Context, pid int) (session, error) {
-	return s.GetSessionForPredicate(ctx, func(sess session) bool {
-		return sess.PID == int32(pid)
-	})
-}
-
 // GetSessionForPath returns the session for the given path
 func (s *sessionManager) GetSessionForPath(ctx context.Context, path string) (session, error) {
 	return s.GetSessionForPredicate(ctx, func(sess session) bool {


### PR DESCRIPTION
Instead of tracking a PID to monitor the process, we're now determining whether or not the directory is still in use.

- On windows, we do this my attempting to re-name the directory.
- On macOS / Linux, we leverage `lsof`.