### PR TITLE
Backend Updates

### DIFF
--- a/internal/config/editors/editor.go
+++ b/internal/config/editors/editor.go
@@ -31,17 +31,6 @@ var AllTrackingTypes = []TrackingType{
 	TrackingTypeProcess,
 }
 
-type EditorRunType string
-
-func (e EditorRunType) String() string {
-	return string(e)
-}
-
-const (
-	EditorRunTypeStart EditorRunType = "start"
-	EditorRunTypeRun   EditorRunType = "run"
-)
-
 func GetTrackingType(value string) (TrackingType, error) {
 	for _, t := range AllTrackingTypes {
 		if t.String() == value {
@@ -54,7 +43,6 @@ func GetTrackingType(value string) (TrackingType, error) {
 
 type Editor struct {
 	Name                EditorName    `json:"name"`
-	RunType             EditorRunType `json:"run_type"`
 	ExecPath            string        `json:"path"`
 	Args                string        `json:"args"`
 	ProcessCaptureDelay time.Duration `json:"process_capture_delay"`

--- a/internal/config/editors/editor.notepad++.go
+++ b/internal/config/editors/editor.notepad++.go
@@ -9,10 +9,9 @@ const (
 func NotepadPlusPlusEditor() Editor {
 	return Editor{
 		Name:                EditorNameNotepadPlusPlus,
-		RunType:             EditorRunTypeStart,
 		ExecPath:            "C:\\Program Files\\Notepad++\\notepad++.exe",
 		Args:                "-multiInst -openFoldersAsWorkspace",
-		ProcessCaptureDelay: time.Second * 2,
+		ProcessCaptureDelay: time.Second * 5,
 		TrackingType:        TrackingTypeProcess,
 	}
 }

--- a/internal/config/editors/editor.vscode.go
+++ b/internal/config/editors/editor.vscode.go
@@ -30,10 +30,9 @@ func VSCodeEditor() Editor {
 
 	return Editor{
 		Name:                EditorNameVSCode,
-		RunType:             EditorRunTypeRun,
 		ExecPath:            vsCodePath,
 		Args:                "-n",
-		ProcessCaptureDelay: time.Second * 2,
+		ProcessCaptureDelay: time.Second * 5,
 		TrackingType:        TrackingTypeFileAccess,
 	}
 }

--- a/internal/logging/log.go
+++ b/internal/logging/log.go
@@ -53,6 +53,13 @@ func (l *logger) File() *os.File {
 	return nil
 }
 
+func (l *logger) ChildLogger(prefix string) *logger {
+	return &logger{
+		Logger: log.New(l.Writer(), fmt.Sprintf("%s%s: ", logPrefix, prefix), log.LstdFlags),
+		cfg:    l.cfg,
+	}
+}
+
 func New(cfg *LoggerConfig) (*logger, error) {
 	storageManager := storage.GetStorage()
 


### PR DESCRIPTION
- Removed editor run type and instead default to cmd.Start()
- Updated process capture delay default to 5s
- Added better logging for session monitoring